### PR TITLE
Update to show 64 bit on builds.

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -32,5 +32,5 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: obliteration-win32
+        name: obliteration-win64
         path: dist


### PR DESCRIPTION
We compile 64-bit builds because the PS4 uses a 64 Bit CPU... Yet the file name was ending with win32, I changed it to win64