### PR TITLE
Expect a Zlib header when decompressing.

### DIFF
--- a/src/pfs/src/pfsc.rs
+++ b/src/pfs/src/pfsc.rs
@@ -1,4 +1,4 @@
-use flate2::read::ZlibDecoder;
+use flate2::FlushDecompress;
 use std::cmp::min;
 use std::error::Error;
 use std::fmt::{Display, Formatter};

--- a/src/pfs/src/pfsc.rs
+++ b/src/pfs/src/pfsc.rs
@@ -1,4 +1,4 @@
-use flate2::FlushDecompress;
+use flate2::read::ZlibDecoder;
 use std::cmp::min;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
@@ -100,13 +100,13 @@ impl<F: Read + Seek> Reader<F> {
             buf.fill(0);
         } else {
             // Read compressed.
-            let mut compressed = new_buffer(size as usize - 2);
+            let mut compressed = new_buffer(size as usize);
 
-            self.file.seek(SeekFrom::Start(offset + 2))?;
+            self.file.seek(SeekFrom::Start(offset))?;
             self.file.read_exact(&mut compressed)?;
 
             // Decompress.
-            let mut deflate = flate2::Decompress::new(false);
+            let mut deflate = flate2::Decompress::new(true);
             let status = match deflate.decompress(&compressed, buf, FlushDecompress::Finish) {
                 Ok(v) => v,
                 Err(e) => return Err(std::io::Error::new(ErrorKind::Other, e)),


### PR DESCRIPTION
Decompress has a setting specifically for ZLib files, testing to see if this works.